### PR TITLE
v1.0.0

### DIFF
--- a/.github/workflows/ArtifactsDownload.yml
+++ b/.github/workflows/ArtifactsDownload.yml
@@ -188,7 +188,7 @@ jobs:
         uses: pyTooling/download-artifact@dev
         with:
           name: release-2
-          path: artifact
+          path: myDownload
 
       - name: 🔎 Inspect extracted artifact (tarball)
         run: |
@@ -207,9 +207,9 @@ jobs:
           echo "----------------------------------------"
           
           echo -n "Was tarball removed ... "
-          if [[ -f artifact/__upload_artifact__.tar ]]; then
+          if [[ -f myDownload/__upload_artifact__.tar ]]; then
             echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
-            echo -e "${ANSI_LIGHT_RED}Artifact's tarball 'artifact/__upload_artifact__.tar' still exists.${ANSI_NOCOLOR}"
+            echo -e "${ANSI_LIGHT_RED}Artifact's tarball 'myDownload/__upload_artifact__.tar' still exists.${ANSI_NOCOLOR}"
             exit 1
           else
             echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
@@ -224,11 +224,11 @@ jobs:
           ANSI_NOCOLOR="\e[0m"
 
           expected=(
-            "artifact/document1.txt"
-            "artifact/analysis.log"
-            "artifact/build.log"
-            "artifact/bin/program.py"
-            "artifact/lib/common.py"
+            "myDownload/document1.txt"
+            "myDownload/analysis.log"
+            "myDownload/build.log"
+            "myDownload/bin/program.py"
+            "myDownload/lib/common.py"
           )
 
           errors=0          
@@ -259,8 +259,8 @@ jobs:
           ANSI_NOCOLOR="\e[0m"
 
           expected=(
-            "artifact/bin/program.py"
-            "artifact/lib/common.py"
+            "myDownload/bin/program.py"
+            "myDownload/lib/common.py"
           )
 
           errors=0          
@@ -282,3 +282,122 @@ jobs:
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
 
+  Verify-3:
+    name: Verify 3 - Artifact contents
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+      - Build-2
+
+    steps:
+      - name: 📥 Download artifact
+        uses: pyTooling/download-artifact@dev
+        with:
+          path: myDownload
+
+      - name: 🔎 Inspect extracted artifact (tarball)
+        run: |
+          tree .
+
+      - name: 🔎 Inspect cleanup
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+          
+          echo "List directory content"
+          ls -lAh .
+          echo "----------------------------------------"
+          
+          echo -n "Was tarball of 'release-1' removed ... "
+          if [[ -f myDownload/release-1/__upload_artifact__.tar ]]; then
+            echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+            echo -e "${ANSI_LIGHT_RED}Artifact's tarball 'myDownload/release-1/__upload_artifact__.tar' still exists.${ANSI_NOCOLOR}"
+            exit 1
+          else
+            echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+          fi
+          echo -n "Was tarball of 'release-2' removed ... "
+          if [[ -f myDownload/release-2/__upload_artifact__.tar ]]; then
+            echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+            echo -e "${ANSI_LIGHT_RED}Artifact's tarball 'myDownload/release-2/__upload_artifact__.tar' still exists.${ANSI_NOCOLOR}"
+            exit 1
+          else
+            echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+          fi
+
+      - name: 📋 Verify extracted artifact content
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+
+          expected=(
+            "myDownload/release-1/document1.txt"
+            "myDownload/release-1/analysis.log"
+            "myDownload/release-1/build.log"
+            "myDownload/release-1/bin/program.py"
+            "myDownload/release-1/lib/common.py"
+            "myDownload/release-2/document1.txt"
+            "myDownload/release-2/analysis.log"
+            "myDownload/release-2/build.log"
+            "myDownload/release-2/bin/program.py"
+            "myDownload/release-2/lib/common.py"
+          )
+
+          errors=0          
+          for file in "${expected[@]}"; do
+            echo -n "Checking '${file}' ... "
+            if [[ -f "$file" ]]; then
+              echo -e "${ANSI_LIGHT_GREEN}[PASSED]${ANSI_NOCOLOR}"
+            else
+              echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+              echo -e "${ANSI_LIGHT_RED}Extracted artifact doesn't contain file '${file}'.${ANSI_NOCOLOR}"
+              errors=$((errors + 1))
+            fi  
+          done
+          
+          echo ""
+          if [[ $errors -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
+          fi
+
+      - name: 📋 Verify file permissions
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+
+          expected=(
+            "myDownload/release-1/bin/program.py"
+            "myDownload/release-1/lib/common.py"
+            "myDownload/release-2/bin/program.py"
+            "myDownload/release-2/lib/common.py"
+          )
+
+          errors=0          
+          for file in "${expected[@]}"; do
+            echo -n "Checking '${file}' ... "
+            if [[ -x "$file" ]]; then
+              echo -e "${ANSI_LIGHT_GREEN}[PASSED]${ANSI_NOCOLOR}"
+            else
+              echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+              echo -e "${ANSI_LIGHT_RED}File '${file}' isn't executable.${ANSI_NOCOLOR}"
+              errors=$((errors + 1))
+            fi  
+          done
+          
+          echo ""
+          if [[ $errors -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
+          fi

--- a/.github/workflows/ArtifactsDownload.yml
+++ b/.github/workflows/ArtifactsDownload.yml
@@ -1,0 +1,111 @@
+name: Verification of Preserving Artifact Upload
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  Build-1:
+    name: Upload artifact
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: 🖉 Build 1
+        run: |
+          echo "Document 1 $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > document1.txt
+          echo "Analysis log $(date --utc '+%d.%m.%Y - %H:%M:%S')" > analysis.log
+          echo "Build log $(date --utc '+%d.%m.%Y - %H:%M:%S')"    > build.log
+          
+          mkdir -p bin
+          echo "Program $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > bin/program.py
+          
+          mkdir -p lib
+          echo "Library $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/common.py
+
+      - name: 🔎 Inspect directory structure
+        run: |
+          tree .
+
+      - name: 📤 Upload artifact
+        uses: pyTooling/upload-artifact@dev
+        with:
+          name: release-1
+          path: |
+            document1.txt
+            *.log
+            bin/
+            lib/*.py
+#          if-no-files-found: error
+#          retention-days: 1
+
+  Verify-1:
+    name: Verify artifact content
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: pyTooling/download-artifact@dev
+        with:
+          name: release-1
+
+      - name: 🔎 Inspect extracted artifact (tarball)
+        run: |
+          tree .
+
+      - name: 🔎 Inspect cleanup
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+          
+          echo "List directory content"
+          ls -lAh . 
+          echo "----------------------------------------"
+          
+          echo -n "Was tarball removed ... "
+          if [[ -f __upload_artifact__.tar ]]; then
+            echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+            echo -e "${ANSI_LIGHT_RED}Artifact's tarball '__upload_artifact__.tar' still exists.${ANSI_NOCOLOR}"
+            exit 1
+          else
+            echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+          fi
+
+      - name: 📋 Verify extracted artifact content
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+
+          expected=(
+            "document1.txt"
+            "analysis.log"
+            "build.log"
+            "bin/program.py"
+            "lib/common.py"
+          )
+
+          errors=0          
+          for file in "${expected[@]}"; do
+            echo -n "Checking '${file}' ... "
+            if [[ -f "$file" ]]; then
+              echo -e "${ANSI_LIGHT_GREEN}[PASSED]${ANSI_NOCOLOR}"
+            else
+              echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+              echo -e "${ANSI_LIGHT_RED}Extracted artifact doesn't contain file '${file}'.${ANSI_NOCOLOR}"
+              errors=$((errors + 1))
+            fi  
+          done
+          
+          echo ""
+          if [[ $errors -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
+          fi

--- a/.github/workflows/ArtifactsDownload.yml
+++ b/.github/workflows/ArtifactsDownload.yml
@@ -18,13 +18,15 @@ jobs:
           
           mkdir -p bin
           echo "Program $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > bin/program.py
+          chmod u+x bin/program.py
           
           mkdir -p lib
           echo "Library $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/common.py
+          chmod +x lib/common.py
 
       - name: 🔎 Inspect directory structure
         run: |
-          tree .
+          tree -psh .
 
       - name: 📤 Upload artifact
         uses: pyTooling/upload-artifact@dev
@@ -59,7 +61,7 @@ jobs:
 
       - name: 🔎 Inspect directory structure
         run: |
-          tree .
+          tree -psh .
 
       - name: 📤 Upload artifact
         uses: pyTooling/upload-artifact@dev
@@ -87,7 +89,7 @@ jobs:
 
       - name: 🔎 Inspect extracted artifact (tarball)
         run: |
-          tree .
+          tree -psh .
 
       - name: 🔎 Inspect cleanup
         run: |
@@ -141,6 +143,7 @@ jobs:
           echo ""
           if [[ $errors -ne 0 ]]; then
             echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+            exit 1
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
@@ -173,6 +176,7 @@ jobs:
           echo ""
           if [[ $errors -ne 0 ]]; then
             echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+            exit 1
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
@@ -192,7 +196,7 @@ jobs:
 
       - name: 🔎 Inspect extracted artifact (tarball)
         run: |
-          tree .
+          tree -psh .
 
       - name: 🔎 Inspect cleanup
         run: |
@@ -246,6 +250,7 @@ jobs:
           echo ""
           if [[ $errors -ne 0 ]]; then
             echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+            exit 1
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
@@ -278,6 +283,7 @@ jobs:
           echo ""
           if [[ $errors -ne 0 ]]; then
             echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+            exit 1
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
@@ -297,7 +303,7 @@ jobs:
 
       - name: 🔎 Inspect extracted artifact (tarball)
         run: |
-          tree .
+          tree -psh .
 
       - name: 🔎 Inspect cleanup
         run: |
@@ -364,6 +370,7 @@ jobs:
           echo ""
           if [[ $errors -ne 0 ]]; then
             echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+            exit 1
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
@@ -398,6 +405,7 @@ jobs:
           echo ""
           if [[ $errors -ne 0 ]]; then
             echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+            exit 1
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi

--- a/.github/workflows/ArtifactsDownload.yml
+++ b/.github/workflows/ArtifactsDownload.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Build-1:
-    name: Upload artifact
+    name: Build 1 - Upload artifact
     runs-on: ubuntu-24.04
 
     steps:
@@ -38,8 +38,43 @@ jobs:
 #          if-no-files-found: error
 #          retention-days: 1
 
+  Build-2:
+    name: Build 2 - Upload artifact
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: 🖉 Build 2
+        run: |
+          echo "Document 1 $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > document1.txt
+          echo "Analysis log $(date --utc '+%d.%m.%Y - %H:%M:%S')" > analysis.log
+          echo "Build log $(date --utc '+%d.%m.%Y - %H:%M:%S')"    > build.log
+          
+          mkdir -p bin
+          echo "Program $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > bin/program.py
+          chmod u+x bin/program.py
+          
+          mkdir -p lib
+          echo "Library $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/common.py
+          chmod +x lib/common.py
+
+      - name: 🔎 Inspect directory structure
+        run: |
+          tree .
+
+      - name: 📤 Upload artifact
+        uses: pyTooling/upload-artifact@dev
+        with:
+          name: release-2
+          path: |
+            document1.txt
+            *.log
+            bin/
+            lib/*.py
+#          if-no-files-found: error
+#          retention-days: 1
+
   Verify-1:
-    name: Verify artifact content
+    name: Verify 1 - Artifact content
     runs-on: ubuntu-24.04
     needs:
       - Build-1
@@ -63,7 +98,7 @@ jobs:
           ANSI_NOCOLOR="\e[0m"
           
           echo "List directory content"
-          ls -lAh . 
+          ls -lAh .
           echo "----------------------------------------"
           
           echo -n "Was tarball removed ... "
@@ -109,3 +144,141 @@ jobs:
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
+
+      - name: 📋 Verify file permissions
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+
+          expected=(
+            "bin/program.py"
+            "lib/common.py"
+          )
+
+          errors=0          
+          for file in "${expected[@]}"; do
+            echo -n "Checking '${file}' ... "
+            if [[ -x "$file" ]]; then
+              echo -e "${ANSI_LIGHT_GREEN}[PASSED]${ANSI_NOCOLOR}"
+            else
+              echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+              echo -e "${ANSI_LIGHT_RED}File '${file}' isn't executable.${ANSI_NOCOLOR}"
+              errors=$((errors + 1))
+            fi  
+          done
+          
+          echo ""
+          if [[ $errors -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
+          fi
+
+  Verify-2:
+    name: Verify 2 - Artifact content in directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-2
+
+    steps:
+      - name: 📥 Download artifact
+        uses: pyTooling/download-artifact@dev
+        with:
+          name: release-2
+          path: artifact
+
+      - name: 🔎 Inspect extracted artifact (tarball)
+        run: |
+          tree .
+
+      - name: 🔎 Inspect cleanup
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+          
+          echo "List directory content"
+          ls -lAh .
+          echo "----------------------------------------"
+          
+          echo -n "Was tarball removed ... "
+          if [[ -f artifact/__upload_artifact__.tar ]]; then
+            echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+            echo -e "${ANSI_LIGHT_RED}Artifact's tarball 'artifact/__upload_artifact__.tar' still exists.${ANSI_NOCOLOR}"
+            exit 1
+          else
+            echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+          fi
+
+      - name: 📋 Verify extracted artifact content
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+
+          expected=(
+            "artifact/document1.txt"
+            "artifact/analysis.log"
+            "artifact/build.log"
+            "artifact/bin/program.py"
+            "artifact/lib/common.py"
+          )
+
+          errors=0          
+          for file in "${expected[@]}"; do
+            echo -n "Checking '${file}' ... "
+            if [[ -f "$file" ]]; then
+              echo -e "${ANSI_LIGHT_GREEN}[PASSED]${ANSI_NOCOLOR}"
+            else
+              echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+              echo -e "${ANSI_LIGHT_RED}Extracted artifact doesn't contain file '${file}'.${ANSI_NOCOLOR}"
+              errors=$((errors + 1))
+            fi  
+          done
+          
+          echo ""
+          if [[ $errors -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
+          fi
+
+      - name: 📋 Verify file permissions
+        run: |
+          set +e
+
+          ANSI_LIGHT_RED="\e[91m"
+          ANSI_LIGHT_GREEN="\e[92m"
+          ANSI_NOCOLOR="\e[0m"
+
+          expected=(
+            "artifact/bin/program.py"
+            "artifact/lib/common.py"
+          )
+
+          errors=0          
+          for file in "${expected[@]}"; do
+            echo -n "Checking '${file}' ... "
+            if [[ -x "$file" ]]; then
+              echo -e "${ANSI_LIGHT_GREEN}[PASSED]${ANSI_NOCOLOR}"
+            else
+              echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+              echo -e "${ANSI_LIGHT_RED}File '${file}' isn't executable.${ANSI_NOCOLOR}"
+              errors=$((errors + 1))
+            fi  
+          done
+          
+          echo ""
+          if [[ $errors -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}Counted ${errors} errors.${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
+          fi
+

--- a/.idea/download-artifact.iml
+++ b/.idea/download-artifact.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/download-artifact.iml" filepath="$PROJECT_DIR$/.idea/download-artifact.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Preserving Artifact Download Action
+
+**Based on:**
+ * [actions/upload-artifact#38 - upload-artifact does not retain artifact permissions (08. Sep. 2024)](https://github.com/actions/upload-artifact/issues/38#issuecomment-2336484584)
+ * [Gist: 
+rcdailey/download-tar-action.yml](https://gist.github.com/rcdailey/cd3437bb2c63647126aa5740824b2a4f)

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,11 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |
-        set -x
+        set +e
+
+        ANSI_LIGHT_RED="\e[91m"
+        ANSI_LIGHT_GREEN="\e[92m"
+        ANSI_NOCOLOR="\e[0m"
 
         if [[ "${{ inputs.name }}" == "" ]]; then
           dirs=(*/)
@@ -83,10 +87,16 @@ runs:
         fi
 
         for dir in "${dirs[@]}"; do
-          echo "> Extracting: $dir"
           pushd "$dir" > /dev/null
-          tar -xvf artifact.tar
-          rm artifact.tar
+        
+          echo -n "Extracting tarball '${dir}/${{ inputs.temp_tarball }}' ... "
+          tar -xf "${{ inputs.temp_tarball }}"
+          if [[ $? -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+          fi
+          
           popd > /dev/null
         done
 

--- a/action.yml
+++ b/action.yml
@@ -64,13 +64,20 @@ runs:
   steps:
     # https://github.com/actions/download-artifact
     - name: Download artifact
-      uses: actions/download-artifact@v4
       id: download
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
 
+    - name: 🔎 Inspect after download
+      id: inspect
+      shell: bash
+      run: |
+        tree .
+
     - name: Extract tarball content(s)
+      id: extract
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |
@@ -103,6 +110,7 @@ runs:
     - name: Remove temporary tarball
       id: cleanup
       shell: bash
+      working-directory: ${{ inputs.path }}
       run: |
         set +e
 
@@ -110,10 +118,18 @@ runs:
         ANSI_LIGHT_GREEN="\e[92m"
         ANSI_NOCOLOR="\e[0m"
         
-        echo -n "Removing temporary tarball(s) ... "
-        rm -f "${{ inputs.temp_tarball }}"
-        if [[ $? -ne 0 ]]; then
-          echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+        if [[ "${{ inputs.name }}" == "" ]]; then
+          artifactDirectories=(*/)
         else
-          echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+          artifactDirectories=(.)
         fi
+        
+        for artifactDirectory in "${artifactDirectories[@]}"; do
+          echo -n "Removing temporary tarball ... "
+          rm -f "${artifactDirectory}/${{ inputs.temp_tarball }}"
+          if [[ $? -ne 0 ]]; then
+            echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+          else
+            echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+          fi
+        done

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,109 @@
+name: Download (preserving) Artifact(s)
+description: Download the artifact(s) with preserved file privileges which were previously uploaded by the 'upload-artifact' action.
+author: Patrick Lehmann (@Paebbels)
+
+inputs:
+  name:
+    description: |
+      Name of the artifact to download.
+      If unspecified, all artifacts for the run are downloaded.
+      Optional.
+    required: false
+  path:
+    description: |
+      Destination path. Supports basic tilde expansion.
+      Optional. Default is $GITHUB_WORKSPACE
+    required: false
+  pattern:
+    description: |
+      A glob pattern to the artifacts that should be downloaded.
+      Ignored if name is specified.
+      Optional.
+    required: false
+  merge-multiple:
+    description: |
+      When multiple artifacts are matched, this changes the behavior of the destination directories.
+      If true, the downloaded artifacts will be in the same directory specified by path.
+      If false, the downloaded artifacts will be extracted into individual named directories within the specified path.
+      Optional. Default is 'false'
+    type: boolean
+    required: false
+    default: false
+  github-token:
+    description: |
+      The GitHub token used to authenticate with the GitHub API.
+      This is required when downloading artifacts from a different repository or from a different workflow run.
+      Optional. If unspecified, the action will download artifacts from the current repo and the current workflow run.
+    required: false
+  repository:
+    description: |
+      The repository owner and the repository name joined together by "/".
+      If github-token is specified, this is the repository that artifacts will be downloaded from.
+      Optional.
+#      Default is ${{ github.repository }}
+    required: false
+  run-id:
+    description: |
+      The id of the workflow run where the desired download artifact was uploaded from.
+      If github-token is specified, this is the run that artifacts will be downloaded from.
+      Optional.
+#      Default is ${{ github.run_id }}
+    required: false
+  temp_tarball:
+    type: string
+    required: false
+    default: '__upload_artifact__.tar'
+
+outputs:
+  download-path:
+    description: Absolute path where the artifact(s) were downloaded.
+    value: ${{ steps.download.outputs.download-path }}
+
+runs:
+  using: composite
+  steps:
+    # https://github.com/actions/download-artifact
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      id: download
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+
+    - name: Extract tarball content(s)
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: |
+        set -x
+
+        if [[ "${{ inputs.name }}" == "" ]]; then
+          dirs=(*/)
+        else
+          dirs=(.)
+        fi
+
+        for dir in "${dirs[@]}"; do
+          echo "> Extracting: $dir"
+          pushd "$dir" > /dev/null
+          tar -xvf artifact.tar
+          rm artifact.tar
+          popd > /dev/null
+        done
+
+    - name: Remove temporary tarball
+      id: cleanup
+      shell: bash
+      run: |
+        set +e
+
+        ANSI_LIGHT_RED="\e[91m"
+        ANSI_LIGHT_GREEN="\e[92m"
+        ANSI_NOCOLOR="\e[0m"
+        
+        echo -n "Removing temporary tarball(s) ... "
+        rm -f "${{ inputs.temp_tarball }}"
+        if [[ $? -ne 0 ]]; then
+          echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+        else
+          echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+        fi

--- a/action.yml
+++ b/action.yml
@@ -69,12 +69,17 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}
+        merge-multiple: ${{ inputs.merge-multiple }}
+        github-token: ${{ inputs.github-token }}
+        repository: ${{ inputs.repository }}
+        run-id: ${{ inputs.run-id }}
 
     - name: 🔎 Inspect after download
       id: inspect
       shell: bash
       run: |
-        tree .
+        tree -psh .
 
     - name: Extract tarball content(s)
       id: extract

--- a/action.yml
+++ b/action.yml
@@ -81,15 +81,15 @@ runs:
         ANSI_NOCOLOR="\e[0m"
 
         if [[ "${{ inputs.name }}" == "" ]]; then
-          dirs=(*/)
+          artifactDirectories=(*/)
         else
-          dirs=(.)
+          artifactDirectories=(.)
         fi
 
-        for dir in "${dirs[@]}"; do
-          pushd "$dir" > /dev/null
+        for artifactDirectory in "${artifactDirectories[@]}"; do
+          pushd "${artifactDirectory}" > /dev/null
         
-          echo -n "Extracting tarball '${dir}/${{ inputs.temp_tarball }}' ... "
+          echo -n "Extracting tarball '${artifactDirectory}/${{ inputs.temp_tarball }}' ... "
           tar -xf "${{ inputs.temp_tarball }}"
           if [[ $? -ne 0 ]]; then
             echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"


### PR DESCRIPTION
# New Features

Developed a drop-in-replacement of `download-artifact` as a composite action, which preserved file attributes like permissions. All input parameters of `download-artifact` are forwarded to the original action.

The implementation uses a tarball (`*.tar`) to preserve file permissions. After packaging/unpackaging, the tarball is removed in a cleanup phase.

# Unit Tests

A pipeline was added, which verifies different scenarios like:
* single artifact download
* single artifact download into a directory
* multiple artifact download into a directory