### PR TITLE
Updating v8 from main@1.9.0

### DIFF
--- a/.github/workflows/ArtifactsDownload.yml
+++ b/.github/workflows/ArtifactsDownload.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   Prepare:
-    uses: pyTooling/Actions/.github/workflows/PrepareJob.yml@r6
+    uses: pyTooling/Actions/.github/workflows/PrepareJob.yml@r7
 
   Build-1:
     name: ${{ matrix.os.icon }} Build 1 on ${{ matrix.os.name }} - Upload artifact
@@ -361,7 +361,7 @@ jobs:
 
 
   TriggerTaggedRelease:
-    uses: pyTooling/Actions/.github/workflows/TagReleaseCommit.yml@r6
+    uses: pyTooling/Actions/.github/workflows/TagReleaseCommit.yml@r7
     needs:
       - Prepare
       - Verify-ProjectRoot

--- a/.github/workflows/ArtifactsDownload.yml
+++ b/.github/workflows/ArtifactsDownload.yml
@@ -43,8 +43,8 @@ jobs:
 
       - uses: ./.github/actions/create-files
 
-      - name: 📤 Upload artifact via 'actions/upload-artifact@v6'
-        uses: actions/upload-artifact@v6
+      - name: 📤 Upload artifact via 'actions/upload-artifact@v7'
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.os.name }}-legacy
           path: |

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
   steps:
     # https://github.com/actions/download-artifact
     - name: 📥 Download artifact
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       id: download
       with:
         name: ${{ inputs.name }}


### PR DESCRIPTION
# Changes

* Bumped dependencies.
  * Bump actions/download-artifact from 7 to 8.

# Tests

* Bumped dependencies.
  * Bump actions/upload-artifact from 6 to 7.
  * Bump pyTooling/upload-artifact from 6 to 7.
  * Updated reusable templates from pyTooling/Actions to r7.

----------
# Related Issues and Pull-Requests

* #40